### PR TITLE
Provision Jenkins plugins

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -15,6 +15,16 @@
       service:
         name: jenkins
         state: started
+    - name: install jenkins plugin github
+      jenkins_plugin:
+        name: github
+        url_username: admin
+        url_password: admin
+    - name: install jenkins plugin publish over ssh
+      jenkins_plugin:
+        name: publish-over-ssh
+        url_username: admin
+        url_password: admin
   roles:
     - role: geerlingguy.java
       when: "ansible_os_family == 'RedHat'"


### PR DESCRIPTION
Because of a bug in Ansible, the target plugin `git` cannot be
installed directly, so the `github` plugin is installed instead
(which then gets `git` as a dependency).

Note that the Jenkins service must be manually restarted before
use or these plugins will not be available for use.